### PR TITLE
Minor fix for %GREEN% color variable

### DIFF
--- a/syntaxes/pd2lootfilter.tmGrammar.json
+++ b/syntaxes/pd2lootfilter.tmGrammar.json
@@ -72,7 +72,7 @@
         "action-keyword":{
             "patterns": [{
                 "name": "entity.name.function",
-                "match": "%(DARK_GREEN|GOLD|TAN|BLUE|GRAY|WHITE|BLACK|YELLOW|ORANGE|PURPLE|RED)%"
+                "match": "%(DARK_GREEN|GREEN|GOLD|TAN|BLUE|GRAY|WHITE|BLACK|YELLOW|ORANGE|PURPLE|RED)%"
             }, {
                 "name": "variable",
                 "match": "%(PRICE|ILVL|SOCKETS|CODE|NAME|GEMTYPE|GEMLEVEL|RUNENAME|RUNENUM|QTY|ALVL|CLVL|RANGE|WPNSPD)%"


### PR DESCRIPTION
Minor fix for `%GREEN%` variable highlighting to be consistent with other color variables.  Very nice extension, thank you for writing it!